### PR TITLE
Add validation loss to model

### DIFF
--- a/TAPE/train.py
+++ b/TAPE/train.py
@@ -1,14 +1,16 @@
-import torch
 import random
+
 import numpy as np
 import pandas as pd
-from tqdm import tqdm
-from torch.optim import Adam
+import torch
 import torch.nn.functional as F
+from torch.optim import Adam
 from torch.utils.data import DataLoader
+from tqdm import tqdm
 
 from .model import simdatset, AutoEncoder, device
 from .utils import showloss
+
 
 def reproducibility(seed=1):
     torch.manual_seed(seed)
@@ -19,25 +21,40 @@ def reproducibility(seed=1):
         torch.backends.cudnn.deterministic = True
 
 
-def training_stage(model, train_loader, optimizer, epochs=128):
-    
-    model.train()
-    model.state = 'train'
+def training_stage(model, train_loader, optimizer, epochs=128, validation: None | tuple[np.ndarray, np.ndarray] = None):
     loss = []
     recon_loss = []
-    
-    for i in tqdm(range(epochs)):
-        for k, (data, label) in enumerate(train_loader):
+    validation_loss = []
+    validation_recon_loss = []
+    val_data = torch.from_numpy(validation[0]).float().to(device) if validation else None
+    val_label = torch.from_numpy(validation[1]).float().to(device) if validation else None
+
+    for _ in tqdm(range(epochs)):
+        model.train()
+        model.state = 'train'
+        running_loss, running_recon_loss, running_total = 0.0, 0.0, 0
+        for _, (data, label) in enumerate(train_loader):
             # reproducibility(seed=0)
             optimizer.zero_grad()
             x_recon, cell_prop, sigm = model(data)
-            batch_loss = F.l1_loss(cell_prop, label) + F.l1_loss(x_recon, data) 
+            batch_loss = F.l1_loss(cell_prop, label) + F.l1_loss(x_recon, data)
             batch_loss.backward()
             optimizer.step()
-            loss.append(F.l1_loss(cell_prop, label).cpu().detach().numpy())
-            recon_loss.append(F.l1_loss(x_recon, data).cpu().detach().numpy())
+            running_loss += F.l1_loss(cell_prop, label).item() * data.size(0)
+            running_recon_loss += F.l1_loss(x_recon, data).item() * data.size(0)
+            running_total += label.size(0)
+        loss.append(running_loss / running_total)
+        recon_loss.append(running_loss / running_total)
 
-    return model, loss, recon_loss
+        if validation is not None:  # compute validation losses
+            model.eval()
+            model.state = 'test'
+            x_recon, cell_prop, _ = model(val_data)
+            validation_loss.append(F.l1_loss(cell_prop, val_label).cpu().detach().numpy())
+            validation_recon_loss.append(F.l1_loss(x_recon, val_data).cpu().detach().numpy())
+
+    return model, loss, recon_loss, validation_loss, validation_recon_loss
+
 
 def adaptive_stage(model, data, optimizerD, optimizerE, step=10, max_iter=5):
     data = torch.from_numpy(data).float().to(device)
@@ -48,14 +65,14 @@ def adaptive_stage(model, data, optimizerD, optimizerE, step=10, max_iter=5):
     ori_sigm = ori_sigm.detach()
     ori_pred = ori_pred.detach()
     model.state = 'train'
-    
+
     for k in range(max_iter):
         model.train()
         for i in range(step):
             reproducibility(seed=0)
             optimizerD.zero_grad()
             x_recon, _, sigm = model(data)
-            batch_loss = F.l1_loss(x_recon, data)+F.l1_loss(sigm,ori_sigm)
+            batch_loss = F.l1_loss(x_recon, data) + F.l1_loss(sigm, ori_sigm)
             batch_loss.backward()
             optimizerD.step()
             loss.append(F.l1_loss(x_recon, data).cpu().detach().numpy())
@@ -64,7 +81,7 @@ def adaptive_stage(model, data, optimizerD, optimizerE, step=10, max_iter=5):
             reproducibility(seed=0)
             optimizerE.zero_grad()
             x_recon, pred, _ = model(data)
-            batch_loss = F.l1_loss(ori_pred, pred)+F.l1_loss(x_recon, data)
+            batch_loss = F.l1_loss(ori_pred, pred) + F.l1_loss(x_recon, data)
             batch_loss.backward()
             optimizerE.step()
             loss.append(F.l1_loss(x_recon, data).cpu().detach().numpy())
@@ -74,30 +91,33 @@ def adaptive_stage(model, data, optimizerD, optimizerE, step=10, max_iter=5):
     _, pred, sigm = model(data)
     return sigm.cpu().detach().numpy(), loss, pred.detach().cpu().numpy()
 
+
 def train_model(train_x, train_y,
                 model_name=None,
-                batch_size=128, epochs=128):
-    
+                batch_size=128, epochs=128,
+                validation: None | tuple[np.ndarray, np.ndarray] = None):
     train_loader = DataLoader(simdatset(train_x, train_y), batch_size=batch_size, shuffle=True)
     model = AutoEncoder(train_x.shape[1], train_y.shape[1]).to(device)
     # reproducibility(seed=0)
     optimizer = Adam(model.parameters(), lr=1e-4)
     print('Start training')
-    model, loss, reconloss = training_stage(model, train_loader, optimizer, epochs=epochs)
+    model, loss, reconloss, valloss, valreconloss = training_stage(model, train_loader,
+                                                                   optimizer, epochs=epochs,
+                                                                   validation=validation)
     print('Training is done')
     print('prediction loss is:')
-    showloss(loss)
+    showloss(loss, valloss)
     print('reconstruction loss is:')
-    showloss(reconloss)
+    showloss(reconloss, valreconloss)
     if model_name is not None:
         print('Model is saved')
-        torch.save(model, model_name+".pth")
+        torch.save(model, model_name + ".pth")
     return model
+
 
 def predict(test_x, genename, celltypes, samplename,
             model_name=None, model=None,
             adaptive=True, mode='overall'):
-    
     if model is not None and model_name is None:
         print('Model is saved without defined name')
         torch.save(model, 'model.pth')
@@ -107,7 +127,7 @@ def predict(test_x, genename, celltypes, samplename,
             TestPred = np.zeros((test_x.shape[0], len(celltypes)))
             print('Start adaptive training at high-resolution')
             for i in tqdm(range(len(test_x))):
-                x = test_x[i,:].reshape(1,-1)
+                x = test_x[i, :].reshape(1, -1)
                 if model_name is not None and model is None:
                     model = torch.load(model_name + ".pth")
                 elif model is not None and model_name is None:
@@ -118,13 +138,13 @@ def predict(test_x, genename, celltypes, samplename,
                 optimizerE = torch.optim.Adam(encoder_parameters, lr=1e-4)
                 test_sigm, loss, test_pred = adaptive_stage(model, x, optimizerD, optimizerE, step=300, max_iter=3)
                 TestSigmList[i, :, :] = test_sigm
-                TestPred[i,:] = test_pred
-            TestPred = pd.DataFrame(TestPred,columns=celltypes,index=samplename)
+                TestPred[i, :] = test_pred
+            TestPred = pd.DataFrame(TestPred, columns=celltypes, index=samplename)
             CellTypeSigm = {}
             for i in range(len(celltypes)):
                 cellname = celltypes[i]
-                sigm = TestSigmList[:,i,:]
-                sigm = pd.DataFrame(sigm,columns=genename,index=samplename)
+                sigm = TestSigmList[:, i, :]
+                sigm = pd.DataFrame(sigm, columns=genename, index=samplename)
                 CellTypeSigm[cellname] = sigm
             print('Adaptive stage is done')
 
@@ -142,14 +162,14 @@ def predict(test_x, genename, celltypes, samplename,
             print('Start adaptive training for all the samples')
             test_sigm, loss, test_pred = adaptive_stage(model, test_x, optimizerD, optimizerE, step=300, max_iter=3)
             print('Adaptive stage is done')
-            test_sigm = pd.DataFrame(test_sigm,columns=genename,index=celltypes)
-            test_pred = pd.DataFrame(test_pred,columns=celltypes,index=samplename)
+            test_sigm = pd.DataFrame(test_sigm, columns=genename, index=celltypes)
+            test_pred = pd.DataFrame(test_pred, columns=celltypes, index=samplename)
 
             return test_sigm, test_pred
 
     else:
         if model_name is not None and model is None:
-            model = torch.load(model_name+".pth")
+            model = torch.load(model_name + ".pth")
         elif model is not None and model_name is None:
             model = model
         print('Predict cell fractions without adaptive training')
@@ -161,7 +181,3 @@ def predict(test_x, genename, celltypes, samplename,
         pred = pd.DataFrame(pred, columns=celltypes, index=samplename)
         print('Prediction is done')
         return pred
-
-
-
-

--- a/TAPE/utils.py
+++ b/TAPE/utils.py
@@ -172,11 +172,14 @@ def score(pred, label):
     print('CCC is ', CCCscore(pred, label))
 
 
-def showloss(loss):
+def showloss(loss, val_loss=[]):
     sns.set()
-    plt.plot(loss)
+    plt.plot(loss, label='training loss')
+    if val_loss:
+        plt.plot(val_loss, label='validation loss')
     plt.xlabel('iteration')
     plt.ylabel('loss')
+    plt.legend()
     plt.show()
 
 


### PR DESCRIPTION
### Description
This change adds an optional validation loss for both reconstruction and proportions.
- Computes the average loss on validation set, e.g. 

This change also computes the training loss for each training iteration (i.e. to match the number of epoch). 
- Current loss curve shows training loss per batch instead of iteration

### Example Loss Curve
![image](https://github.com/poseidonchan/TAPE/assets/55815682/9475e7ba-b701-4212-844b-a85fce4ad0f1)
